### PR TITLE
Implement horizontal flip for s2dex bg copy

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2395,6 +2395,14 @@ static void gfx_s2dex_bg_copy(uObjBg* bg) {
         data = (uintptr_t) reinterpret_cast<char*>(tex->ImageData);
     }
 
+    s16 dsdx = 4 << 10;
+    s16 uls = bg->b.imageX << 3;
+    // Flip flag only flips horizontally
+    if (bg->b.imageFlip & G_BG_FLAG_FLIPS) {
+        dsdx = -dsdx;
+        uls = (bg->b.imageW - bg->b.imageX) << 3;
+    }
+
     SUPPORT_CHECK(bg->b.imageSiz == G_IM_SIZ_16b);
     gfx_dp_set_texture_image(G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, nullptr, texFlags, rawTexMetadata, (void*)data);
     gfx_dp_set_tile(G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, 0, G_TX_LOADTILE, 0, 0, 0, 0, 0, 0, 0);
@@ -2403,8 +2411,8 @@ static void gfx_s2dex_bg_copy(uObjBg* bg) {
                     0);
     gfx_dp_set_tile_size(G_TX_RENDERTILE, 0, 0, bg->b.imageW, bg->b.imageH);
     gfx_dp_texture_rectangle(bg->b.frameX, bg->b.frameY, bg->b.frameX + bg->b.imageW - 4,
-                             bg->b.frameY + bg->b.imageH - 4, G_TX_RENDERTILE, bg->b.imageX << 3, bg->b.imageY << 3,
-                             4 << 10, 1 << 10, bg->b.imageFlip);
+                             bg->b.frameY + bg->b.imageH - 4, G_TX_RENDERTILE, uls, bg->b.imageY << 3,
+                             dsdx, 1 << 10, false);
 }
 
 static inline void* seg_addr(uintptr_t w1) {

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2257,8 +2257,12 @@ static void gfx_dp_texture_rectangle(int32_t ulx, int32_t uly, int32_t lrx, int3
     // dsdx and dtdy are S5.10
     // lrx, lry, ulx, uly are U10.2
     // lrs, lrt are S10.5
-    int16_t width = lrx - ulx;
-    int16_t height = lry - uly;
+    if (flip) {
+        dsdx = -dsdx;
+        dtdy = -dtdy;
+    }
+    int16_t width = !flip ? lrx - ulx : lry - uly;
+    int16_t height = !flip ? lry - uly : lrx - ulx;
     float lrs = ((uls << 7) + dsdx * width) >> 7;
     float lrt = ((ult << 7) + dtdy * height) >> 7;
 
@@ -2266,26 +2270,20 @@ static void gfx_dp_texture_rectangle(int32_t ulx, int32_t uly, int32_t lrx, int3
     struct LoadedVertex* ll = &rsp.loaded_vertices[MAX_VERTICES + 1];
     struct LoadedVertex* lr = &rsp.loaded_vertices[MAX_VERTICES + 2];
     struct LoadedVertex* ur = &rsp.loaded_vertices[MAX_VERTICES + 3];
-    if (flip) {
-        // Flip the texture horizontally
-        ul->u = lrs;
-        ul->v = ult;
-        ll->u = lrs;
-        ll->v = lrt;
-        lr->u = uls;
-        lr->v = lrt;
-        ur->u = uls;
-        ur->v = ult;
-    } else {
-        // No horizontal flip
-        ul->u = uls;
-        ul->v = ult;
+    ul->u = uls;
+    ul->v = ult;
+    lr->u = lrs;
+    lr->v = lrt;
+    if (!flip) {
         ll->u = uls;
         ll->v = lrt;
-        lr->u = lrs;
-        lr->v = lrt;
         ur->u = lrs;
         ur->v = ult;
+    } else {
+        ll->u = lrs;
+        ll->v = ult;
+        ur->u = uls;
+        ur->v = lrt;
     }
 
     uint8_t saved_tile = rdp.first_tile_index;


### PR DESCRIPTION
This reverts the texture rectangle flip changes back to n64 standard (flips both s-axis and t-axis).
This implements the missing s-axis flipping for `gSPBgRectCopy` as detailed here http://n64devkit.square7.ch/n64man/gsp/gSPBgRectCopy.htm for Fast3D.

The `imageFlip` flag only supports horizontal flipping, and the flipping logic happens within this macro by reversing the dsdx value and starting the s-axis on the right edge instead of left edge.