### PR TITLE
mark texel 0 as used when in 2cyc mode

### DIFF
--- a/src/graphic/Fast3D/gfx_cc.cpp
+++ b/src/graphic/Fast3D/gfx_cc.cpp
@@ -44,6 +44,9 @@ void gfx_cc_get_features(uint64_t shader_id0, uint32_t shader_id1, struct CCFeat
                 }
                 if (cc_features->c[c][i][j] == SHADER_TEXEL1 || cc_features->c[c][i][j] == SHADER_TEXEL1A) {
                     cc_features->used_textures[1] = true;
+                    if (cc_features->opt_2cyc) {
+                        cc_features->used_textures[0] = true;
+                    }
                 }
             }
         }

--- a/src/graphic/Fast3D/gfx_metal_shader.cpp
+++ b/src/graphic/Fast3D/gfx_metal_shader.cpp
@@ -29,7 +29,7 @@ static void append_line(char* buf, size_t* len, const char* str) {
     buf[(*len)++] = '\n';
 }
 
-static const char* shader_item_to_str(uint32_t item, bool with_alpha, bool only_alpha, bool inputs_have_alpha,
+static const char* shader_item_to_str(uint32_t item, bool with_alpha, bool only_alpha, bool inputs_have_alpha, bool first_cycle,
                                       bool hint_single_element) {
     if (!only_alpha) {
         switch (item) {
@@ -46,17 +46,25 @@ static const char* shader_item_to_str(uint32_t item, bool with_alpha, bool only_
             case SHADER_INPUT_4:
                 return with_alpha || !inputs_have_alpha ? "in.input4" : "in.input4.xyz";
             case SHADER_TEXEL0:
-                return with_alpha ? "texVal0" : "texVal0.xyz";
+                return first_cycle ? (with_alpha ? "texVal0" : "texVal0.xyz") : (with_alpha ? "texVal1" : "texVal1.xyz");
             case SHADER_TEXEL0A:
-                return hint_single_element ? "texVal0.w"
+                return first_cycle ? (hint_single_element ? "texVal0.w"
                                            : (with_alpha ? "float4(texVal0.w, texVal0.w, texVal0.w, texVal0.w)"
-                                                         : "float3(texVal0.w, texVal0.w, texVal0.w)");
-            case SHADER_TEXEL1A:
-                return hint_single_element ? "texVal1.w"
+                                                         : "float3(texVal0.w, texVal0.w, texVal0.w)")) : (
+                                                            hint_single_element ? "texVal1.w"
                                            : (with_alpha ? "float4(texVal1.w, texVal1.w, texVal1.w, texVal1.w)"
-                                                         : "float3(texVal1.w, texVal1.w, texVal1.w)");
+                                                         : "float3(texVal1.w, texVal1.w, texVal1.w)")
+                                                         );
+            case SHADER_TEXEL1A:
+                return first_cycle ? (hint_single_element ? "texVal1.w"
+                                           : (with_alpha ? "float4(texVal1.w, texVal1.w, texVal1.w, texVal1.w)"
+                                                         : "float3(texVal1.w, texVal1.w, texVal1.w)")) : (
+                                    hint_single_element ? "texVal0.w"
+                                            : (with_alpha ? "float4(texVal0.w, texVal0.w, texVal0.w, texVal0.w)"
+                                                            : "float3(texVal0.w, texVal0.w, texVal0.w)")
+                                                         );
             case SHADER_TEXEL1:
-                return with_alpha ? "texVal1" : "texVal1.xyz";
+                return first_cycle ? (with_alpha ? "texVal1" : "texVal1.xyz") : (with_alpha ? "texVal0" : "texVal0.xyz");
             case SHADER_COMBINED:
                 return with_alpha ? "texel" : "texel.xyz";
             case SHADER_NOISE:
@@ -78,13 +86,13 @@ static const char* shader_item_to_str(uint32_t item, bool with_alpha, bool only_
             case SHADER_INPUT_4:
                 return "in.input4.w";
             case SHADER_TEXEL0:
-                return "texVal0.w";
+                return first_cycle ? "texVal0.w" : "texVal1.w";
             case SHADER_TEXEL0A:
-                return "texVal0.w";
+                return first_cycle ? "texVal0.w" : "texVal1.w";
             case SHADER_TEXEL1A:
-                return "texVal1.w";
+                return first_cycle ? "texVal1.w" : "texVal0.w";
             case SHADER_TEXEL1:
-                return "texVal1.w";
+                return first_cycle ? "texVal1.w" : "texVal0.w";
             case SHADER_COMBINED:
                 return "texel.w";
             case SHADER_NOISE:
@@ -97,30 +105,30 @@ static const char* shader_item_to_str(uint32_t item, bool with_alpha, bool only_
 #undef RAND_NOISE
 
 static void append_formula(char* buf, size_t* len, const uint8_t c[2][4], bool do_single, bool do_multiply, bool do_mix,
-                           bool with_alpha, bool only_alpha, bool opt_alpha) {
+                           bool with_alpha, bool only_alpha, bool opt_alpha, bool first_cycle) {
     if (do_single) {
-        append_str(buf, len, shader_item_to_str(c[only_alpha][3], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][3], with_alpha, only_alpha, opt_alpha, first_cycle, false));
     } else if (do_multiply) {
-        append_str(buf, len, shader_item_to_str(c[only_alpha][0], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][0], with_alpha, only_alpha, opt_alpha, first_cycle, false));
         append_str(buf, len, " * ");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][2], with_alpha, only_alpha, opt_alpha, true));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][2], with_alpha, only_alpha, opt_alpha, first_cycle, true));
     } else if (do_mix) {
         append_str(buf, len, "mix(");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][1], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][1], with_alpha, only_alpha, opt_alpha, first_cycle, false));
         append_str(buf, len, ", ");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][0], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][0], with_alpha, only_alpha, opt_alpha, first_cycle, false));
         append_str(buf, len, ", ");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][2], with_alpha, only_alpha, opt_alpha, true));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][2], with_alpha, only_alpha, opt_alpha, first_cycle, true));
         append_str(buf, len, ")");
     } else {
         append_str(buf, len, "(");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][0], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][0], with_alpha, only_alpha, opt_alpha, first_cycle, false));
         append_str(buf, len, " - ");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][1], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][1], with_alpha, only_alpha, opt_alpha, first_cycle, false));
         append_str(buf, len, ") * ");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][2], with_alpha, only_alpha, opt_alpha, true));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][2], with_alpha, only_alpha, opt_alpha, first_cycle, true));
         append_str(buf, len, " + ");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][3], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][3], with_alpha, only_alpha, opt_alpha, first_cycle, false));
     }
 }
 
@@ -412,14 +420,14 @@ MTL::VertexDescriptor* gfx_metal_build_shader(char buf[8192], size_t& num_floats
         if (!cc_features.color_alpha_same[c] && cc_features.opt_alpha) {
             append_str(buf, &len, "float4(");
             append_formula(buf, &len, cc_features.c[c], cc_features.do_single[c][0], cc_features.do_multiply[c][0],
-                           cc_features.do_mix[c][0], false, false, true);
+                           cc_features.do_mix[c][0], false, false, true, c == 0);
             append_str(buf, &len, ", ");
             append_formula(buf, &len, cc_features.c[c], cc_features.do_single[c][1], cc_features.do_multiply[c][1],
-                           cc_features.do_mix[c][1], true, true, true);
+                           cc_features.do_mix[c][1], true, true, true, c == 0);
             append_str(buf, &len, ")");
         } else {
             append_formula(buf, &len, cc_features.c[c], cc_features.do_single[c][0], cc_features.do_multiply[c][0],
-                           cc_features.do_mix[c][0], cc_features.opt_alpha, false, cc_features.opt_alpha);
+                           cc_features.do_mix[c][0], cc_features.opt_alpha, false, cc_features.opt_alpha, c == 0);
         }
         append_line(buf, &len, ";");
     }

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -153,7 +153,7 @@ static void append_line(char* buf, size_t* len, const char* str) {
 
 #define RAND_NOISE "((random(vec3(floor(gl_FragCoord.xy * noise_scale), float(frame_count))) + 1.0) / 2.0)"
 
-static const char* shader_item_to_str(uint32_t item, bool with_alpha, bool only_alpha, bool inputs_have_alpha,
+static const char* shader_item_to_str(uint32_t item, bool with_alpha, bool only_alpha, bool inputs_have_alpha, bool first_cycle,
                                       bool hint_single_element) {
     if (!only_alpha) {
         switch (item) {
@@ -170,17 +170,23 @@ static const char* shader_item_to_str(uint32_t item, bool with_alpha, bool only_
             case SHADER_INPUT_4:
                 return with_alpha || !inputs_have_alpha ? "vInput4" : "vInput4.rgb";
             case SHADER_TEXEL0:
-                return with_alpha ? "texVal0" : "texVal0.rgb";
+                return first_cycle ? (with_alpha ? "texVal0" : "texVal0.rgb") : (with_alpha ? "texVal1" : "texVal1.rgb");
             case SHADER_TEXEL0A:
-                return hint_single_element ? "texVal0.a"
+                return first_cycle ? (hint_single_element ? "texVal0.a"
                                            : (with_alpha ? "vec4(texVal0.a, texVal0.a, texVal0.a, texVal0.a)"
-                                                         : "vec3(texVal0.a, texVal0.a, texVal0.a)");
-            case SHADER_TEXEL1A:
-                return hint_single_element ? "texVal1.a"
+                                                         : "vec3(texVal0.a, texVal0.a, texVal0.a)")) : (
+                                        hint_single_element ? "texVal1.a"
                                            : (with_alpha ? "vec4(texVal1.a, texVal1.a, texVal1.a, texVal1.a)"
-                                                         : "vec3(texVal1.a, texVal1.a, texVal1.a)");
+                                                         : "vec3(texVal1.a, texVal1.a, texVal1.a)"));
+            case SHADER_TEXEL1A:
+                return first_cycle ? (hint_single_element ? "texVal1.a"
+                                           : (with_alpha ? "vec4(texVal1.a, texVal1.a, texVal1.a, texVal1.a)"
+                                                         : "vec3(texVal1.a, texVal1.a, texVal1.a)")) : (
+                                    hint_single_element ? "texVal0.a"
+                                           : (with_alpha ? "vec4(texVal0.a, texVal0.a, texVal0.a, texVal0.a)"
+                                                         : "vec3(texVal0.a, texVal0.a, texVal0.a)"));
             case SHADER_TEXEL1:
-                return with_alpha ? "texVal1" : "texVal1.rgb";
+                return first_cycle ? (with_alpha ? "texVal1" : "texVal1.rgb") : (with_alpha ? "texVal0" : "texVal0.rgb");
             case SHADER_COMBINED:
                 return with_alpha ? "texel" : "texel.rgb";
             case SHADER_NOISE:
@@ -202,13 +208,13 @@ static const char* shader_item_to_str(uint32_t item, bool with_alpha, bool only_
             case SHADER_INPUT_4:
                 return "vInput4.a";
             case SHADER_TEXEL0:
-                return "texVal0.a";
+                return first_cycle ? "texVal0.a" : "texVal1.a";
             case SHADER_TEXEL0A:
-                return "texVal0.a";
+                return first_cycle ? "texVal0.a" : "texVal1.a";
             case SHADER_TEXEL1A:
-                return "texVal1.a";
+                return first_cycle ? "texVal1.a" : "texVal0.a";
             case SHADER_TEXEL1:
-                return "texVal1.a";
+                return first_cycle ? "texVal1.a" : "texVal0.a";
             case SHADER_COMBINED:
                 return "texel.a";
             case SHADER_NOISE:
@@ -221,30 +227,30 @@ static const char* shader_item_to_str(uint32_t item, bool with_alpha, bool only_
 #undef RAND_NOISE
 
 static void append_formula(char* buf, size_t* len, uint8_t c[2][4], bool do_single, bool do_multiply, bool do_mix,
-                           bool with_alpha, bool only_alpha, bool opt_alpha) {
+                           bool with_alpha, bool only_alpha, bool opt_alpha, bool first_cycle) {
     if (do_single) {
-        append_str(buf, len, shader_item_to_str(c[only_alpha][3], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][3], with_alpha, only_alpha, opt_alpha, first_cycle, false));
     } else if (do_multiply) {
-        append_str(buf, len, shader_item_to_str(c[only_alpha][0], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][0], with_alpha, only_alpha, opt_alpha, first_cycle, false));
         append_str(buf, len, " * ");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][2], with_alpha, only_alpha, opt_alpha, true));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][2], with_alpha, only_alpha, opt_alpha, first_cycle, true));
     } else if (do_mix) {
         append_str(buf, len, "mix(");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][1], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][1], with_alpha, only_alpha, opt_alpha, first_cycle, false));
         append_str(buf, len, ", ");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][0], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][0], with_alpha, only_alpha, opt_alpha, first_cycle, false));
         append_str(buf, len, ", ");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][2], with_alpha, only_alpha, opt_alpha, true));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][2], with_alpha, only_alpha, opt_alpha, first_cycle, true));
         append_str(buf, len, ")");
     } else {
         append_str(buf, len, "(");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][0], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][0], with_alpha, only_alpha, opt_alpha, first_cycle, false));
         append_str(buf, len, " - ");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][1], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][1], with_alpha, only_alpha, opt_alpha, first_cycle, false));
         append_str(buf, len, ") * ");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][2], with_alpha, only_alpha, opt_alpha, true));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][2], with_alpha, only_alpha, opt_alpha, first_cycle, true));
         append_str(buf, len, " + ");
-        append_str(buf, len, shader_item_to_str(c[only_alpha][3], with_alpha, only_alpha, opt_alpha, false));
+        append_str(buf, len, shader_item_to_str(c[only_alpha][3], with_alpha, only_alpha, opt_alpha, first_cycle, false));
     }
 }
 
@@ -541,15 +547,15 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
         if (!cc_features.color_alpha_same[c] && cc_features.opt_alpha) {
             append_str(fs_buf, &fs_len, "vec4(");
             append_formula(fs_buf, &fs_len, cc_features.c[c], cc_features.do_single[c][0],
-                           cc_features.do_multiply[c][0], cc_features.do_mix[c][0], false, false, true);
+                           cc_features.do_multiply[c][0], cc_features.do_mix[c][0], false, false, true, c == 0);
             append_str(fs_buf, &fs_len, ", ");
             append_formula(fs_buf, &fs_len, cc_features.c[c], cc_features.do_single[c][1],
-                           cc_features.do_multiply[c][1], cc_features.do_mix[c][1], true, true, true);
+                           cc_features.do_multiply[c][1], cc_features.do_mix[c][1], true, true, true, c == 0);
             append_str(fs_buf, &fs_len, ")");
         } else {
             append_formula(fs_buf, &fs_len, cc_features.c[c], cc_features.do_single[c][0],
                            cc_features.do_multiply[c][0], cc_features.do_mix[c][0], cc_features.opt_alpha, false,
-                           cc_features.opt_alpha);
+                           cc_features.opt_alpha, c == 0);
         }
         append_line(fs_buf, &fs_len, ";");
     }

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -340,6 +340,9 @@ static void gfx_generate_cc(struct ColorCombiner* comb, const ColorCombinerKey& 
                     case G_CCMUX_TEXEL1:
                         val = SHADER_TEXEL1;
                         used_textures[1] = true;
+                        if (is_2cyc) {
+                            used_textures[0] = true;
+                        }
                         break;
                     case G_CCMUX_TEXEL0_ALPHA:
                         val = SHADER_TEXEL0A;
@@ -348,6 +351,9 @@ static void gfx_generate_cc(struct ColorCombiner* comb, const ColorCombinerKey& 
                     case G_CCMUX_TEXEL1_ALPHA:
                         val = SHADER_TEXEL1A;
                         used_textures[1] = true;
+                        if (is_2cyc) {
+                            used_textures[0] = true;
+                        }
                         break;
                     case G_CCMUX_NOISE:
                         val = SHADER_NOISE;
@@ -393,6 +399,9 @@ static void gfx_generate_cc(struct ColorCombiner* comb, const ColorCombinerKey& 
                     case G_ACMUX_TEXEL1:
                         val = SHADER_TEXEL1;
                         used_textures[1] = true;
+                        if (is_2cyc) {
+                            used_textures[0] = true;
+                        }
                         break;
                     case G_ACMUX_LOD_FRACTION:
                         // case G_ACMUX_COMBINED: same numerical value


### PR DESCRIPTION
Marking texel 0 as active when in 2 cycle mode seems to prevent the crash when rendering the Aliens

This is probably not the right way to fix this. I'm not sure if we can just blanket assume/mark texel0 as used in 2 cycle mode or not. I couldn't find any documentation that supported that thought.